### PR TITLE
[feature] 指定文字を除外するモードを追加する

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,15 @@ other
 # ランダムな1文字を出力
 $ ./five-letter-word.py -r
 could
+
+# 文字を除外(複数指定=カンマ区切り)
+$ cat hhh
+about
+other
+which
+
+$ ./five-letter-word.py -f hhh -i a,c
+other
 ```
 
 

--- a/five-letter-word.py
+++ b/five-letter-word.py
@@ -11,14 +11,22 @@ def get_five_letter_words(fn: str) -> List[str]:
     except:
         return []
 
+def is_exit_ignore_letter(word: str, ignore_letters: List[str]) -> bool:
+     return len([l for l in list(word) if l in ignore_letters]) > 0
+
 if __name__ == '__main__':
     parser = OptionParser()
     parser.add_option('-r', '--random', action='store_true', dest='show_random', default=False)
     parser.add_option('-f', '--file', dest='fnm_word_list', default='./word.list')
+    parser.add_option('-i', '--ignore', dest='ignore_letters', default='')
     parser.parse_args()
     options, args = parser.parse_args()
 
+    ignore_letters = [l for l in options.ignore_letters.split(',') if l != '']
+
     words = get_five_letter_words(options.fnm_word_list)
+    if len(words) > 0 and len(ignore_letters) > 0:
+        words = [w for w in words if not is_exit_ignore_letter(w, ignore_letters)]
     if options.show_random:
         print(words[randint(1, len(words))])
     else:


### PR DESCRIPTION
#4 の対応

## test

```
$ ./five-letter-word.py -i , | wc -l
    1382
$ ./five-letter-word.py | wc -l
    1382
$ ./five-letter-word.py -i a, | wc -l
     809
$ ./five-letter-word.py -i a, | grep a
$ ./five-letter-word.py | grep a | wc -l
     573
$ ./five-letter-word.py  | grep -v a | wc -l
     809
$ ./five-letter-word.py -i ,a | grep a
$
```